### PR TITLE
feat: add light and dark mode toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-11
+### Added
+- Persistent light and dark theme toggle for the portfolio experience
+- Theme toggle tests covering default, persistence, and interaction
+
+### Changed
+- Updated portfolio sections to support both light and dark mode styling
+- Corrected README naming and documented the theme feature
+- Removed runtime staging log from version control
+
 ## [0.1.0] - 2026-03-11
 ### Added
 - Initial static photographer portfolio landing page
 - About, gallery, and contact sections
 - Jest and React Testing Library setup with component tests
-
-### Changed
-- Removed runtime staging log from version control
-- Corrected README naming and added customization note

--- a/README.md
+++ b/README.md
@@ -1,7 +1,47 @@
 # OpenClaw Photographer Portfolio
 
-Repository initialized.
+## Description
+A static personal portfolio and photo showcase for a photographer, built as a polished single-page site with an about section, featured gallery, contact form, and persistent light/dark mode toggle.
 
+## Tech Stack
+- Next.js (App Router) + TypeScript + Tailwind CSS
+- Jest + React Testing Library
+- Static deployment with `next build` and `next start`
+
+## Getting Started
+```bash
+npm install --include=dev
+npm run dev
+```
+
+## Features
+- Hero section with photographer branding and call-to-action
+- About me section with profile summary and key stats
+- Photo showcase grid for featured work
+- Contact form section for inquiries
+- Persistent light/dark theme toggle
+- Responsive single-page layout
+
+## API Endpoints
+None. This project is fully static.
+
+## Database Schema
+None. This project does not use a database.
+
+## Project Structure
+```text
+src/
+├── app/          # App Router pages and global styles
+├── components/   # Reusable page sections and theme toggle
+└── lib/          # Typed portfolio content
+```
+
+## Staging
+After a successful production build, run:
+```bash
+npm run build
+npm run start -- --hostname 0.0.0.0 --port 8080
+```
 
 ## Notes
 - Built as a static single-page showcase with placeholder content ready to customize.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,11 @@
   --foreground: #1c1917;
 }
 
+html[data-theme="dark"] {
+  --background: #0c0a09;
+  --foreground: #f5f5f4;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -26,6 +31,7 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  transition: background-color 200ms ease, color 200ms ease;
 }
 
 a {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,9 +24,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" data-theme="light">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} bg-stone-50 text-stone-950 antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} bg-stone-50 text-stone-950 antialiased transition-colors dark:bg-stone-950 dark:text-stone-50`}
       >
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,31 +2,35 @@ import { AboutSection } from "@/components/about-section";
 import { ContactForm } from "@/components/contact-form";
 import { Hero } from "@/components/hero";
 import { PhotoGallery } from "@/components/photo-gallery";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 export default function Home() {
   return (
-    <main className="min-h-screen bg-[linear-gradient(180deg,#f8f5f0_0%,#f5efe7_45%,#fcfbf8_100%)] text-stone-900">
+    <main className="min-h-screen bg-[linear-gradient(180deg,#f8f5f0_0%,#f5efe7_45%,#fcfbf8_100%)] text-stone-900 transition-colors dark:bg-[linear-gradient(180deg,#0c0a09_0%,#111827_45%,#09090b_100%)] dark:text-stone-100">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 py-8 sm:px-8 lg:px-12 lg:py-10">
-        <header className="flex flex-col gap-4 rounded-full border border-white/70 bg-white/70 px-6 py-4 shadow-sm backdrop-blur md:flex-row md:items-center md:justify-between">
+        <header className="flex flex-col gap-4 rounded-full border border-white/70 bg-white/70 px-6 py-4 shadow-sm backdrop-blur transition-colors md:flex-row md:items-center md:justify-between dark:border-stone-700/80 dark:bg-stone-900/75">
           <div>
-            <p className="text-lg font-semibold tracking-wide text-stone-950">
+            <p className="text-lg font-semibold tracking-wide text-stone-950 dark:text-white">
               Aria Noor Studio
             </p>
-            <p className="text-sm text-stone-600">
+            <p className="text-sm text-stone-600 dark:text-stone-300">
               Personal portfolio and showcase for a modern photographer.
             </p>
           </div>
-          <nav className="flex flex-wrap gap-5 text-sm font-medium text-stone-700">
-            <a href="#about" className="transition hover:text-stone-950">
-              About
-            </a>
-            <a href="#gallery" className="transition hover:text-stone-950">
-              Gallery
-            </a>
-            <a href="#contact" className="transition hover:text-stone-950">
-              Contact
-            </a>
-          </nav>
+          <div className="flex flex-wrap items-center gap-3">
+            <nav className="flex flex-wrap gap-5 text-sm font-medium text-stone-700 dark:text-stone-300">
+              <a href="#about" className="transition hover:text-stone-950 dark:hover:text-white">
+                About
+              </a>
+              <a href="#gallery" className="transition hover:text-stone-950 dark:hover:text-white">
+                Gallery
+              </a>
+              <a href="#contact" className="transition hover:text-stone-950 dark:hover:text-white">
+                Contact
+              </a>
+            </nav>
+            <ThemeToggle />
+          </div>
         </header>
 
         <Hero />

--- a/src/components/__tests__/theme-toggle.test.tsx
+++ b/src/components/__tests__/theme-toggle.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ThemeToggle } from "@/components/theme-toggle";
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.className = "";
+    delete document.documentElement.dataset.theme;
+  });
+
+  it("renders light mode by default and toggles to dark mode", async () => {
+    const user = userEvent.setup();
+
+    render(<ThemeToggle />);
+
+    const button = await screen.findByRole("button", {
+      name: /toggle color theme/i,
+    });
+
+    expect(button).toHaveTextContent(/dark mode/i);
+    expect(document.documentElement.dataset.theme).toBe("light");
+
+    await user.click(button);
+
+    expect(button).toHaveTextContent(/light mode/i);
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(window.localStorage.getItem("portfolio-theme")).toBe("dark");
+  });
+
+  it("hydrates from saved localStorage theme", async () => {
+    window.localStorage.setItem("portfolio-theme", "dark");
+
+    render(<ThemeToggle />);
+
+    const button = await screen.findByRole("button", {
+      name: /toggle color theme/i,
+    });
+
+    expect(button).toHaveTextContent(/light mode/i);
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(button).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/src/components/about-section.tsx
+++ b/src/components/about-section.tsx
@@ -5,29 +5,29 @@ export function AboutSection() {
     <section
       id="about"
       aria-labelledby="about-heading"
-      className="grid gap-8 rounded-[2rem] border border-stone-200 bg-white/80 p-8 shadow-sm lg:grid-cols-[0.85fr_1.15fr]"
+      className="grid gap-8 rounded-[2rem] border border-stone-200 bg-white/80 p-8 shadow-sm transition-colors lg:grid-cols-[0.85fr_1.15fr] dark:border-stone-700 dark:bg-stone-900/80"
     >
       <div className="space-y-4">
-        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-amber-700">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-amber-700 dark:text-amber-300">
           About Me
         </p>
-        <h2 id="about-heading" className="text-3xl font-semibold text-stone-950">
+        <h2 id="about-heading" className="text-3xl font-semibold text-stone-950 dark:text-white">
           A calm eye for people, places, and light.
         </h2>
         <div className="grid gap-4 sm:grid-cols-3">
           {photographerProfile.stats.map((stat) => (
             <div
               key={stat.label}
-              className="rounded-2xl border border-stone-200 bg-stone-50 p-4"
+              className="rounded-2xl border border-stone-200 bg-stone-50 p-4 transition-colors dark:border-stone-700 dark:bg-stone-950/70"
             >
-              <p className="text-2xl font-semibold text-stone-950">{stat.value}</p>
-              <p className="mt-1 text-sm leading-6 text-stone-600">{stat.label}</p>
+              <p className="text-2xl font-semibold text-stone-950 dark:text-white">{stat.value}</p>
+              <p className="mt-1 text-sm leading-6 text-stone-600 dark:text-stone-300">{stat.label}</p>
             </div>
           ))}
         </div>
       </div>
 
-      <div className="space-y-4 text-base leading-8 text-stone-600">
+      <div className="space-y-4 text-base leading-8 text-stone-600 dark:text-stone-300">
         {photographerProfile.about.map((paragraph) => (
           <p key={paragraph}>{paragraph}</p>
         ))}

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -12,34 +12,34 @@ export function ContactForm() {
     <section
       id="contact"
       aria-labelledby="contact-heading"
-      className="grid gap-8 rounded-[2rem] bg-stone-950 px-8 py-10 text-white lg:grid-cols-[0.85fr_1.15fr]"
+      className="grid gap-8 rounded-[2rem] bg-stone-950 px-8 py-10 text-white transition-colors lg:grid-cols-[0.85fr_1.15fr] dark:bg-stone-100 dark:text-stone-950"
     >
       <div className="space-y-4">
-        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-amber-300">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-amber-300 dark:text-amber-700">
           Contact
         </p>
         <h2 id="contact-heading" className="text-3xl font-semibold">
           Let’s create something memorable.
         </h2>
-        <p className="max-w-md text-base leading-7 text-stone-300">
+        <p className="max-w-md text-base leading-7 text-stone-300 dark:text-stone-700">
           Share your vision, timeline, and location. I’ll get back to you with
           availability, package details, and the next best steps.
         </p>
-        <div className="space-y-3 text-sm text-stone-300">
+        <div className="space-y-3 text-sm text-stone-300 dark:text-stone-700">
           <p>Email: {photographerProfile.contact.email}</p>
           <p>Phone: {photographerProfile.contact.phone}</p>
           <p>Instagram: {photographerProfile.contact.instagram}</p>
         </div>
       </div>
 
-      <form className="grid gap-4 rounded-[1.5rem] bg-white p-6 text-stone-900 shadow-2xl">
+      <form className="grid gap-4 rounded-[1.5rem] bg-white p-6 text-stone-900 shadow-2xl dark:bg-stone-950 dark:text-stone-100">
         <div className="grid gap-4 sm:grid-cols-2">
           <label className="grid gap-2 text-sm font-medium">
             Name
             <input
               type="text"
               placeholder="Your name"
-              className="rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+              className="rounded-2xl border border-stone-300 bg-white px-4 py-3 outline-none transition focus:border-stone-950 dark:border-stone-700 dark:bg-stone-900 dark:text-white dark:focus:border-stone-300"
             />
           </label>
           <label className="grid gap-2 text-sm font-medium">
@@ -47,14 +47,14 @@ export function ContactForm() {
             <input
               type="email"
               placeholder="you@example.com"
-              className="rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+              className="rounded-2xl border border-stone-300 bg-white px-4 py-3 outline-none transition focus:border-stone-950 dark:border-stone-700 dark:bg-stone-900 dark:text-white dark:focus:border-stone-300"
             />
           </label>
         </div>
 
         <label className="grid gap-2 text-sm font-medium">
           Inquiry Type
-          <select className="rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950">
+          <select className="rounded-2xl border border-stone-300 bg-white px-4 py-3 outline-none transition focus:border-stone-950 dark:border-stone-700 dark:bg-stone-900 dark:text-white dark:focus:border-stone-300">
             {inquiryTypes.map((type) => (
               <option key={type}>{type}</option>
             ))}
@@ -66,13 +66,13 @@ export function ContactForm() {
           <textarea
             rows={5}
             placeholder="Tell me about the shoot, mood, location, and preferred dates."
-            className="rounded-2xl border border-stone-300 px-4 py-3 outline-none transition focus:border-stone-950"
+            className="rounded-2xl border border-stone-300 bg-white px-4 py-3 outline-none transition focus:border-stone-950 dark:border-stone-700 dark:bg-stone-900 dark:text-white dark:focus:border-stone-300"
           />
         </label>
 
         <button
           type="submit"
-          className="rounded-full bg-stone-950 px-6 py-3 text-sm font-medium text-white transition hover:bg-stone-800"
+          className="rounded-full bg-stone-950 px-6 py-3 text-sm font-medium text-white transition hover:bg-stone-800 dark:bg-white dark:text-stone-950 dark:hover:bg-stone-200"
         >
           Send Inquiry
         </button>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -4,20 +4,20 @@ export function Hero() {
   return (
     <section className="grid gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
       <div className="space-y-6">
-        <p className="text-sm font-semibold uppercase tracking-[0.35em] text-amber-700">
+        <p className="text-sm font-semibold uppercase tracking-[0.35em] text-amber-700 dark:text-amber-300">
           Photographer Portfolio
         </p>
         <div className="space-y-4">
-          <h1 className="max-w-3xl text-5xl font-semibold tracking-tight text-stone-950 sm:text-6xl">
+          <h1 className="max-w-3xl text-5xl font-semibold tracking-tight text-stone-950 sm:text-6xl dark:text-white">
             {photographerProfile.name}
           </h1>
-          <p className="text-xl text-stone-700 sm:text-2xl">
+          <p className="text-xl text-stone-700 sm:text-2xl dark:text-stone-200">
             {photographerProfile.title}
           </p>
-          <p className="max-w-2xl text-lg leading-8 text-stone-600">
+          <p className="max-w-2xl text-lg leading-8 text-stone-600 dark:text-stone-300">
             {photographerProfile.tagline}
           </p>
-          <p className="max-w-2xl text-base leading-7 text-stone-500">
+          <p className="max-w-2xl text-base leading-7 text-stone-500 dark:text-stone-400">
             {photographerProfile.intro}
           </p>
         </div>
@@ -25,24 +25,24 @@ export function Hero() {
         <div className="flex flex-wrap gap-4">
           <a
             href="#gallery"
-            className="rounded-full bg-stone-950 px-6 py-3 text-sm font-medium text-white transition hover:bg-stone-800"
+            className="rounded-full bg-stone-950 px-6 py-3 text-sm font-medium text-white transition hover:bg-stone-800 dark:bg-white dark:text-stone-950 dark:hover:bg-stone-200"
           >
             View Gallery
           </a>
           <a
             href="#contact"
-            className="rounded-full border border-stone-300 px-6 py-3 text-sm font-medium text-stone-700 transition hover:border-stone-950 hover:text-stone-950"
+            className="rounded-full border border-stone-300 px-6 py-3 text-sm font-medium text-stone-700 transition hover:border-stone-950 hover:text-stone-950 dark:border-stone-600 dark:text-stone-200 dark:hover:border-stone-300 dark:hover:text-white"
           >
             Book a Session
           </a>
         </div>
       </div>
 
-      <div className="relative overflow-hidden rounded-[2rem] border border-white/60 bg-white/70 p-6 shadow-[0_30px_80px_rgba(41,37,36,0.12)] backdrop-blur">
+      <div className="relative overflow-hidden rounded-[2rem] border border-white/60 bg-white/70 p-6 shadow-[0_30px_80px_rgba(41,37,36,0.12)] backdrop-blur dark:border-stone-700/80 dark:bg-stone-900/70 dark:shadow-[0_30px_80px_rgba(0,0,0,0.35)]">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(251,191,36,0.22),_transparent_45%),radial-gradient(circle_at_bottom_left,_rgba(251,146,60,0.22),_transparent_35%)]" />
-        <div className="relative flex min-h-[420px] flex-col justify-between rounded-[1.5rem] bg-gradient-to-br from-stone-900 via-stone-800 to-stone-700 p-8 text-white">
+        <div className="relative flex min-h-[420px] flex-col justify-between rounded-[1.5rem] bg-gradient-to-br from-stone-900 via-stone-800 to-stone-700 p-8 text-white dark:from-stone-100 dark:via-stone-200 dark:to-stone-300 dark:text-stone-950">
           <div className="space-y-3">
-            <p className="text-sm uppercase tracking-[0.35em] text-stone-300">
+            <p className="text-sm uppercase tracking-[0.35em] text-stone-300 dark:text-stone-600">
               Featured Work
             </p>
             <h2 className="max-w-sm text-3xl font-semibold leading-tight">
@@ -51,12 +51,12 @@ export function Hero() {
           </div>
 
           <div className="grid grid-cols-2 gap-4">
-            <div className="rounded-3xl bg-white/10 p-4 backdrop-blur-sm">
-              <p className="text-sm text-stone-300">Best for</p>
+            <div className="rounded-3xl bg-white/10 p-4 backdrop-blur-sm dark:bg-stone-950/10">
+              <p className="text-sm text-stone-300 dark:text-stone-600">Best for</p>
               <p className="mt-2 text-lg font-medium">Portraits & editorials</p>
             </div>
-            <div className="rounded-3xl bg-white/10 p-4 backdrop-blur-sm">
-              <p className="text-sm text-stone-300">Based in</p>
+            <div className="rounded-3xl bg-white/10 p-4 backdrop-blur-sm dark:bg-stone-950/10">
+              <p className="text-sm text-stone-300 dark:text-stone-600">Based in</p>
               <p className="mt-2 text-lg font-medium">Thailand</p>
             </div>
           </div>

--- a/src/components/photo-gallery.tsx
+++ b/src/components/photo-gallery.tsx
@@ -4,13 +4,13 @@ export function PhotoGallery() {
   return (
     <section id="gallery" aria-labelledby="gallery-heading" className="space-y-8">
       <div className="space-y-3">
-        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-amber-700">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-amber-700 dark:text-amber-300">
           Photo Showcase
         </p>
-        <h2 id="gallery-heading" className="text-3xl font-semibold text-stone-950">
+        <h2 id="gallery-heading" className="text-3xl font-semibold text-stone-950 dark:text-white">
           Selected frames from recent stories.
         </h2>
-        <p className="max-w-2xl text-base leading-7 text-stone-600">
+        <p className="max-w-2xl text-base leading-7 text-stone-600 dark:text-stone-300">
           A curated mix of portrait sessions, travel work, and documentary-style
           images designed to feel intimate, cinematic, and timeless.
         </p>
@@ -20,7 +20,7 @@ export function PhotoGallery() {
         {galleryItems.map((item) => (
           <article
             key={item.id}
-            className="overflow-hidden rounded-[1.75rem] border border-stone-200 bg-white shadow-sm"
+            className="overflow-hidden rounded-[1.75rem] border border-stone-200 bg-white shadow-sm transition-colors dark:border-stone-700 dark:bg-stone-900"
           >
             <div
               className={`flex h-72 items-end bg-gradient-to-br ${item.accent} p-5`}
@@ -31,8 +31,8 @@ export function PhotoGallery() {
               </div>
             </div>
             <div className="space-y-2 p-5">
-              <h3 className="text-xl font-semibold text-stone-950">{item.title}</h3>
-              <p className="text-sm uppercase tracking-[0.2em] text-stone-500">
+              <h3 className="text-xl font-semibold text-stone-950 dark:text-white">{item.title}</h3>
+              <p className="text-sm uppercase tracking-[0.2em] text-stone-500 dark:text-stone-400">
                 {item.location}
               </p>
             </div>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+const storageKey = "portfolio-theme";
+
+function applyTheme(theme: Theme) {
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.classList.toggle("dark", theme === "dark");
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("light");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const savedTheme = window.localStorage.getItem(storageKey);
+    const nextTheme: Theme = savedTheme === "dark" ? "dark" : "light";
+
+    setTheme(nextTheme);
+    applyTheme(nextTheme);
+    setMounted(true);
+  }, []);
+
+  const toggleTheme = () => {
+    const nextTheme: Theme = theme === "light" ? "dark" : "light";
+
+    setTheme(nextTheme);
+    window.localStorage.setItem(storageKey, nextTheme);
+    applyTheme(nextTheme);
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Toggle color theme"
+      aria-pressed={theme === "dark"}
+      onClick={toggleTheme}
+      className="rounded-full border border-stone-300 bg-white px-4 py-2 text-sm font-medium text-stone-700 shadow-sm transition hover:border-stone-950 hover:text-stone-950 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-200 dark:hover:border-stone-300 dark:hover:text-white"
+    >
+      {mounted ? (theme === "light" ? "🌙 Dark mode" : "☀️ Light mode") : "Theme"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a persistent light/dark mode toggle to the photographer portfolio and updates the page styling so both themes feel polished across the full experience. It also adds test coverage for the theme switch behavior and updates the project docs.

## File Changes
- `CHANGELOG.md` — recorded the new theme toggle release notes
- `README.md` — documented the persistent light/dark mode feature and setup notes
- `next-env.d.ts` — included Next.js generated type definitions in the tracked project files
- `src/app/globals.css` — added theme variables and global transition styling for light/dark mode
- `src/app/layout.tsx` — set the default theme state on the document shell
- `src/app/page.tsx` — added the theme toggle to the header and enabled dark-aware page styling
- `src/components/__tests__/theme-toggle.test.tsx` — added tests for default theme, persistence, and toggle interaction
- `src/components/about-section.tsx` — updated the about section to support both light and dark themes
- `src/components/contact-form.tsx` — updated the contact section and form controls for both themes
- `src/components/hero.tsx` — updated the hero section styling for light and dark mode
- `src/components/photo-gallery.tsx` — updated gallery cards and text styles for both themes
- `src/components/theme-toggle.tsx` — added the client-side theme toggle with localStorage persistence

## Notes
- Tests pass: 4 passed, 0 failed
- Staging verified at http://localhost:8080