### PR TITLE
feat: project-based gallery showcase with lightbox viewer

### DIFF
--- a/src/app/gallery/[projectId]/page.tsx
+++ b/src/app/gallery/[projectId]/page.tsx
@@ -1,0 +1,37 @@
+import { notFound } from "next/navigation";
+import { Navbar } from "@/components/navbar";
+import { ProjectDetailClient } from "@/components/project-detail-client";
+import { projects } from "@/lib/portfolio-data";
+
+type Props = {
+  params: Promise<{ projectId: string }>;
+};
+
+export async function generateStaticParams() {
+  return projects.map((p) => ({ projectId: p.id }));
+}
+
+export async function generateMetadata({ params }: Props) {
+  const { projectId } = await params;
+  const project = projects.find((p) => p.id === projectId);
+  if (!project) return {};
+  return {
+    title: `${project.title} | Aria Noor Studio`,
+    description: project.description,
+  };
+}
+
+export default async function ProjectDetailPage({ params }: Props) {
+  const { projectId } = await params;
+  const project = projects.find((p) => p.id === projectId);
+  if (!project) notFound();
+
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,#f8f5f0_0%,#f5efe7_45%,#fcfbf8_100%)] text-stone-900 transition-colors dark:bg-[linear-gradient(180deg,#0c0a09_0%,#111827_45%,#09090b_100%)] dark:text-stone-100">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 py-8 sm:px-8 lg:px-12 lg:py-10">
+        <Navbar />
+        <ProjectDetailClient project={project} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,4 +1,4 @@
-import { PhotoGallery } from "@/components/photo-gallery";
+import { ProjectGallery } from "@/components/project-gallery";
 import { Navbar } from "@/components/navbar";
 
 export const metadata = {
@@ -11,7 +11,7 @@ export default function GalleryPage() {
     <main className="min-h-screen bg-[linear-gradient(180deg,#f8f5f0_0%,#f5efe7_45%,#fcfbf8_100%)] text-stone-900 transition-colors dark:bg-[linear-gradient(180deg,#0c0a09_0%,#111827_45%,#09090b_100%)] dark:text-stone-100">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 py-8 sm:px-8 lg:px-12 lg:py-10">
         <Navbar />
-        <PhotoGallery />
+        <ProjectGallery />
       </div>
     </main>
   );

--- a/src/components/__tests__/lightbox.test.tsx
+++ b/src/components/__tests__/lightbox.test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { Lightbox } from "@/components/lightbox";
+import type { ProjectImage } from "@/types/project";
+
+// Mock next/image — strip Next.js-only props that are invalid on <img>
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ src, alt, priority: _p, width: _w, height: _h, ...rest }: { src: string; alt: string; priority?: boolean; width?: number; height?: number; [key: string]: unknown }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} {...rest} />
+  ),
+}));
+
+const mockImages: ProjectImage[] = [
+  { id: 1, src: "https://example.com/img1.jpg", alt: "Image one", caption: "Caption one" },
+  { id: 2, src: "https://example.com/img2.jpg", alt: "Image two", caption: "Caption two" },
+  { id: 3, src: "https://example.com/img3.jpg", alt: "Image three" },
+];
+
+describe("Lightbox", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // Immediately invoke rAF callback to avoid act() warnings from mount animation
+    jest.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.runAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("renders the dialog with correct aria attributes", () => {
+    const onClose = jest.fn();
+    render(<Lightbox images={mockImages} initialIndex={0} onClose={onClose} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("displays the current image", () => {
+    const onClose = jest.fn();
+    render(<Lightbox images={mockImages} initialIndex={0} onClose={onClose} />);
+    expect(screen.getByAltText("Image one")).toBeInTheDocument();
+  });
+
+  it("shows the image counter", () => {
+    const onClose = jest.fn();
+    render(<Lightbox images={mockImages} initialIndex={0} onClose={onClose} />);
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+  });
+
+  it("shows caption when available", () => {
+    const onClose = jest.fn();
+    render(<Lightbox images={mockImages} initialIndex={0} onClose={onClose} />);
+    expect(screen.getByText("Caption one")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", () => {
+    const onClose = jest.fn();
+    render(<Lightbox images={mockImages} initialIndex={0} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /close image viewer/i }));
+    act(() => { jest.runAllTimers(); });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when Escape key is pressed", () => {
+    const onClose = jest.fn();
+    render(<Lightbox images={mockImages} initialIndex={0} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    act(() => { jest.runAllTimers(); });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("navigates to next image on ArrowRight", () => {
+    const onClose = jest.fn();
+    render(<Lightbox images={mockImages} initialIndex={0} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    act(() => { jest.runAllTimers(); });
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+  });
+
+  it("navigates to previous image on ArrowLeft", () => {
+    const onClose = jest.fn();
+    render(<Lightbox images={mockImages} initialIndex={1} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    act(() => { jest.runAllTimers(); });
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+  });
+
+  it("renders prev and next buttons", () => {
+    const onClose = jest.fn();
+    render(<Lightbox images={mockImages} initialIndex={0} onClose={onClose} />);
+    expect(screen.getByRole("button", { name: /previous image/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next image/i })).toBeInTheDocument();
+  });
+
+  it("renders dot indicators for each image", () => {
+    const onClose = jest.fn();
+    render(<Lightbox images={mockImages} initialIndex={0} onClose={onClose} />);
+    mockImages.forEach((_, i) => {
+      expect(screen.getByRole("button", { name: `Go to image ${i + 1}` })).toBeInTheDocument();
+    });
+  });
+
+  it("closes when backdrop is clicked", () => {
+    const onClose = jest.fn();
+    render(<Lightbox images={mockImages} initialIndex={0} onClose={onClose} />);
+    const backdrop = document.querySelector('[aria-hidden="true"]');
+    if (backdrop) fireEvent.click(backdrop);
+    act(() => { jest.runAllTimers(); });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/project-gallery.test.tsx
+++ b/src/components/__tests__/project-gallery.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ProjectGallery } from "@/components/project-gallery";
+import { projects } from "@/lib/portfolio-data";
+
+// Mock next/image — strip Next.js-only props that are invalid on <img>
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ src, alt, fill: _fill, sizes: _sizes, ...rest }: { src: string; alt: string; fill?: boolean; sizes?: string; [key: string]: unknown }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} {...rest} />
+  ),
+}));
+
+// Mock next/link
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+describe("ProjectGallery", () => {
+  it("renders the section heading", () => {
+    render(<ProjectGallery />);
+    expect(screen.getByRole("heading", { name: /stories told in frames/i })).toBeInTheDocument();
+  });
+
+  it("renders a card for each project", () => {
+    render(<ProjectGallery />);
+    projects.forEach((project) => {
+      expect(screen.getByRole("link", { name: new RegExp(project.title, "i") })).toBeInTheDocument();
+    });
+  });
+
+  it("renders project titles and locations", () => {
+    render(<ProjectGallery />);
+    projects.forEach((project) => {
+      expect(screen.getByText(project.title)).toBeInTheDocument();
+      expect(screen.getByText(project.location)).toBeInTheDocument();
+    });
+  });
+
+  it("renders image count badges", () => {
+    render(<ProjectGallery />);
+    // All 3 projects have 5 images — use getAllByText since badges are identical
+    const badges = screen.getAllByText(`${projects[0].images.length} photos`);
+    expect(badges).toHaveLength(projects.length);
+  });
+
+  it("links to correct project detail URLs", () => {
+    render(<ProjectGallery />);
+    projects.forEach((project) => {
+      const link = screen.getByRole("link", { name: new RegExp(project.title, "i") });
+      expect(link).toHaveAttribute("href", `/gallery/${project.id}`);
+    });
+  });
+
+  it("renders cover images with alt text", () => {
+    render(<ProjectGallery />);
+    projects.forEach((project) => {
+      expect(screen.getByAltText(project.title)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/lightbox.tsx
+++ b/src/components/lightbox.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import Image from "next/image";
+import { useCallback, useEffect, useState, useRef } from "react";
+import type { ProjectImage } from "@/types/project";
+
+type LightboxProps = {
+  images: ProjectImage[];
+  initialIndex: number;
+  onClose: () => void;
+};
+
+export function Lightbox({ images, initialIndex, onClose }: LightboxProps) {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [isVisible, setIsVisible] = useState(false);
+  const [slideDir, setSlideDir] = useState<"left" | "right" | null>(null);
+  const [isAnimating, setIsAnimating] = useState(false);
+  const touchStartX = useRef<number | null>(null);
+
+  // Mount animation
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setIsVisible(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setIsVisible(false);
+    setTimeout(onClose, 300);
+  }, [onClose]);
+
+  const goTo = useCallback(
+    (index: number, dir: "left" | "right") => {
+      if (isAnimating) return;
+      setIsAnimating(true);
+      setSlideDir(dir);
+      setTimeout(() => {
+        setCurrentIndex(index);
+        setSlideDir(null);
+        setIsAnimating(false);
+      }, 300);
+    },
+    [isAnimating]
+  );
+
+  const goPrev = useCallback(() => {
+    const prev = (currentIndex - 1 + images.length) % images.length;
+    goTo(prev, "right");
+  }, [currentIndex, images.length, goTo]);
+
+  const goNext = useCallback(() => {
+    const next = (currentIndex + 1) % images.length;
+    goTo(next, "left");
+  }, [currentIndex, images.length, goTo]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleClose();
+      if (e.key === "ArrowLeft") goPrev();
+      if (e.key === "ArrowRight") goNext();
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [handleClose, goPrev, goNext]);
+
+  // Prevent body scroll
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, []);
+
+  // Touch / swipe
+  const onTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+  const onTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const diff = touchStartX.current - e.changedTouches[0].clientX;
+    if (Math.abs(diff) > 50) {
+      diff > 0 ? goNext() : goPrev();
+    }
+    touchStartX.current = null;
+  };
+
+  const current = images[currentIndex];
+
+  const slideClass =
+    slideDir === "left"
+      ? "translate-x-[-60px] opacity-0"
+      : slideDir === "right"
+      ? "translate-x-[60px] opacity-0"
+      : "translate-x-0 opacity-100";
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Image viewer: ${current.alt}`}
+      className={`fixed inset-0 z-50 flex items-center justify-center transition-opacity duration-300 ${
+        isVisible ? "opacity-100" : "opacity-0"
+      }`}
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/90 backdrop-blur-sm"
+        onClick={handleClose}
+        aria-hidden="true"
+      />
+
+      {/* Close button */}
+      <button
+        onClick={handleClose}
+        aria-label="Close image viewer"
+        className="absolute right-4 top-4 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white backdrop-blur-sm transition-colors hover:bg-white/25"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+
+      {/* Counter */}
+      <div className="absolute left-1/2 top-4 z-10 -translate-x-1/2 rounded-full bg-white/10 px-4 py-1.5 text-sm font-medium text-white backdrop-blur-sm">
+        {currentIndex + 1} / {images.length}
+      </div>
+
+      {/* Prev button */}
+      {images.length > 1 && (
+        <button
+          onClick={goPrev}
+          aria-label="Previous image"
+          className="absolute left-4 z-10 flex h-11 w-11 items-center justify-center rounded-full bg-white/10 text-white backdrop-blur-sm transition-colors hover:bg-white/25 sm:left-6"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+      )}
+
+      {/* Next button */}
+      {images.length > 1 && (
+        <button
+          onClick={goNext}
+          aria-label="Next image"
+          className="absolute right-4 z-10 flex h-11 w-11 items-center justify-center rounded-full bg-white/10 text-white backdrop-blur-sm transition-colors hover:bg-white/25 sm:right-6"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      )}
+
+      {/* Image */}
+      <div
+        className={`relative z-10 mx-auto flex max-h-[85vh] max-w-5xl flex-col items-center px-16 transition-all duration-300 ${slideClass}`}
+      >
+        <div
+          className={`relative w-full overflow-hidden rounded-2xl shadow-2xl transition-transform duration-300 ${
+            isVisible ? "scale-100" : "scale-95"
+          }`}
+          style={{ maxHeight: "75vh", aspectRatio: "auto" }}
+        >
+          <Image
+            src={current.src}
+            alt={current.alt}
+            width={1200}
+            height={800}
+            className="max-h-[75vh] w-full object-contain"
+            priority
+          />
+        </div>
+
+        {/* Caption */}
+        {current.caption && (
+          <p className="mt-4 text-center text-sm text-white/70">{current.caption}</p>
+        )}
+      </div>
+
+      {/* Dot indicators */}
+      {images.length > 1 && (
+        <div className="absolute bottom-6 left-1/2 z-10 flex -translate-x-1/2 gap-2">
+          {images.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => goTo(i, i > currentIndex ? "left" : "right")}
+              aria-label={`Go to image ${i + 1}`}
+              className={`h-1.5 rounded-full transition-all duration-300 ${
+                i === currentIndex
+                  ? "w-6 bg-white"
+                  : "w-1.5 bg-white/40 hover:bg-white/70"
+              }`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/project-detail-client.tsx
+++ b/src/components/project-detail-client.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import { Lightbox } from "@/components/lightbox";
+import type { Project } from "@/types/project";
+
+type Props = {
+  project: Project;
+};
+
+export function ProjectDetailClient({ project }: Props) {
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  return (
+    <section className="space-y-10">
+      {/* Back navigation */}
+      <Link
+        href="/gallery"
+        className="inline-flex items-center gap-2 text-sm font-medium text-stone-600 transition-colors hover:text-amber-700 dark:text-stone-400 dark:hover:text-amber-300"
+        aria-label="Back to gallery"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Back to Gallery
+      </Link>
+
+      {/* Project header */}
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+            {project.category}
+          </span>
+          <span className="text-xs font-medium uppercase tracking-[0.2em] text-stone-500 dark:text-stone-400">
+            {project.location}
+          </span>
+          <span className="text-xs text-stone-400 dark:text-stone-500">
+            {project.images.length} photos
+          </span>
+        </div>
+        <h1 className="text-4xl font-semibold text-stone-950 dark:text-white">
+          {project.title}
+        </h1>
+        <p className="max-w-2xl text-base leading-7 text-stone-600 dark:text-stone-300">
+          {project.description}
+        </p>
+      </div>
+
+      {/* Image grid */}
+      <div
+        className="columns-1 gap-5 sm:columns-2 lg:columns-3"
+        role="list"
+        aria-label={`Photos from ${project.title}`}
+      >
+        {project.images.map((image, index) => (
+          <div
+            key={image.id}
+            role="listitem"
+            className="mb-5 break-inside-avoid"
+          >
+            <button
+              onClick={() => setLightboxIndex(index)}
+              className="group relative block w-full overflow-hidden rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+              aria-label={`Open ${image.alt} in full screen`}
+            >
+              <Image
+                src={image.src}
+                alt={image.alt}
+                width={600}
+                height={400}
+                className="w-full object-cover transition-transform duration-500 group-hover:scale-105"
+              />
+              {/* Hover overlay */}
+              <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors duration-300 group-hover:bg-black/30">
+                <div className="flex h-12 w-12 scale-75 items-center justify-center rounded-full bg-white/80 opacity-0 backdrop-blur-sm transition-all duration-300 group-hover:scale-100 group-hover:opacity-100">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-5 w-5 text-stone-800"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              {/* Caption */}
+              {image.caption && (
+                <div className="absolute bottom-0 left-0 right-0 translate-y-full bg-gradient-to-t from-black/70 to-transparent px-4 py-3 transition-transform duration-300 group-hover:translate-y-0">
+                  <p className="text-xs text-white/90">{image.caption}</p>
+                </div>
+              )}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* Lightbox */}
+      {lightboxIndex !== null && (
+        <Lightbox
+          images={project.images}
+          initialIndex={lightboxIndex}
+          onClose={() => setLightboxIndex(null)}
+        />
+      )}
+    </section>
+  );
+}

--- a/src/components/project-gallery.tsx
+++ b/src/components/project-gallery.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { projects } from "@/lib/portfolio-data";
+
+export function ProjectGallery() {
+  return (
+    <section id="gallery" aria-labelledby="gallery-heading" className="space-y-10">
+      <div className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-amber-700 dark:text-amber-300">
+          Photo Showcase
+        </p>
+        <h2
+          id="gallery-heading"
+          className="text-3xl font-semibold text-stone-950 dark:text-white"
+        >
+          Stories told in frames.
+        </h2>
+        <p className="max-w-2xl text-base leading-7 text-stone-600 dark:text-stone-300">
+          Each project is a chapter — a place, a moment, a feeling captured
+          with intention. Browse by session and dive into the full story.
+        </p>
+      </div>
+
+      <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        {projects.map((project) => (
+          <Link
+            key={project.id}
+            href={`/gallery/${project.id}`}
+            className="group block overflow-hidden rounded-[1.75rem] border border-stone-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-stone-700 dark:bg-stone-900"
+            aria-label={`View ${project.title} — ${project.images.length} photos`}
+          >
+            {/* Cover image */}
+            <div className="relative h-64 w-full overflow-hidden">
+              <Image
+                src={project.coverImage}
+                alt={project.title}
+                fill
+                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                className="object-cover transition-transform duration-500 group-hover:scale-105"
+              />
+              {/* Gradient overlay */}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent" />
+
+              {/* Category badge */}
+              <div className="absolute left-4 top-4">
+                <span className="rounded-full bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-stone-700 backdrop-blur-sm">
+                  {project.category}
+                </span>
+              </div>
+
+              {/* Image count badge */}
+              <div className="absolute bottom-4 right-4">
+                <span className="rounded-full bg-black/50 px-3 py-1 text-xs font-medium text-white backdrop-blur-sm">
+                  {project.images.length} photos
+                </span>
+              </div>
+            </div>
+
+            {/* Card body */}
+            <div className="space-y-1 p-5">
+              <h3 className="text-lg font-semibold text-stone-950 group-hover:text-amber-700 dark:text-white dark:group-hover:text-amber-300 transition-colors duration-200">
+                {project.title}
+              </h3>
+              <p className="text-xs font-medium uppercase tracking-[0.2em] text-stone-500 dark:text-stone-400">
+                {project.location}
+              </p>
+              <p className="mt-2 line-clamp-2 text-sm leading-6 text-stone-600 dark:text-stone-300">
+                {project.description}
+              </p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/portfolio-data.ts
+++ b/src/lib/portfolio-data.ts
@@ -1,3 +1,134 @@
+import type { Project } from "@/types/project";
+
+export const projects: Project[] = [
+  {
+    id: "pattaya",
+    title: "Pattaya Beach Sessions",
+    description:
+      "Sun-soaked portraits along the Gulf of Thailand coast — golden hour light, open water, and effortless energy.",
+    location: "Pattaya, Thailand",
+    category: "Lifestyle",
+    coverImage:
+      "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=800&q=80&fit=crop",
+    images: [
+      {
+        id: 1,
+        src: "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=1200&q=80&fit=crop",
+        alt: "Golden hour beach portrait",
+        caption: "Golden hour on the shoreline",
+      },
+      {
+        id: 2,
+        src: "https://images.unsplash.com/photo-1519046904884-53103b34b206?w=1200&q=80&fit=crop",
+        alt: "Couple walking on beach at sunset",
+        caption: "Walking into the horizon",
+      },
+      {
+        id: 3,
+        src: "https://images.unsplash.com/photo-1473186505569-9c61870c11f9?w=1200&q=80&fit=crop",
+        alt: "Beach portrait with ocean backdrop",
+        caption: "Soft waves, softer light",
+      },
+      {
+        id: 4,
+        src: "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?w=1200&q=80&fit=crop",
+        alt: "Silhouette at sunset on beach",
+        caption: "Last light of the day",
+      },
+      {
+        id: 5,
+        src: "https://images.unsplash.com/photo-1471922694854-ff1b63b20054?w=1200&q=80&fit=crop",
+        alt: "Tropical beach scenery",
+        caption: "Where the land meets the sea",
+      },
+    ],
+  },
+  {
+    id: "kalaw-pre-wedding",
+    title: "Kalaw Pre-Wedding",
+    description:
+      "A misty mountain love story in the highlands of Myanmar — pine forests, morning fog, and two people completely at ease with each other.",
+    location: "Kalaw, Myanmar",
+    category: "Pre-Wedding",
+    coverImage:
+      "https://images.unsplash.com/photo-1519741497674-611481863552?w=800&q=80&fit=crop",
+    images: [
+      {
+        id: 1,
+        src: "https://images.unsplash.com/photo-1519741497674-611481863552?w=1200&q=80&fit=crop",
+        alt: "Couple in misty mountain forest",
+        caption: "Lost in the mist together",
+      },
+      {
+        id: 2,
+        src: "https://images.unsplash.com/photo-1529636798458-92182e662485?w=1200&q=80&fit=crop",
+        alt: "Pre-wedding portrait in nature",
+        caption: "Pine trees and promises",
+      },
+      {
+        id: 3,
+        src: "https://images.unsplash.com/photo-1606216794074-735e91aa2c92?w=1200&q=80&fit=crop",
+        alt: "Romantic couple portrait outdoors",
+        caption: "A quiet moment between them",
+      },
+      {
+        id: 4,
+        src: "https://images.unsplash.com/photo-1537633552985-df8429e8048b?w=1200&q=80&fit=crop",
+        alt: "Couple walking through forest path",
+        caption: "Every path leads somewhere beautiful",
+      },
+      {
+        id: 5,
+        src: "https://images.unsplash.com/photo-1511285560929-80b456fea0bc?w=1200&q=80&fit=crop",
+        alt: "Romantic sunset portrait",
+        caption: "The mountain holds their story",
+      },
+    ],
+  },
+  {
+    id: "ko-zin-graduation",
+    title: "Ko Zin Graduation",
+    description:
+      "A proud milestone captured with intention — the joy, relief, and quiet pride of a journey completed.",
+    location: "Yangon, Myanmar",
+    category: "Portrait",
+    coverImage:
+      "https://images.unsplash.com/photo-1523050854058-8df90110c9f1?w=800&q=80&fit=crop",
+    images: [
+      {
+        id: 1,
+        src: "https://images.unsplash.com/photo-1523050854058-8df90110c9f1?w=1200&q=80&fit=crop",
+        alt: "Graduation portrait with cap and gown",
+        caption: "The day it all came together",
+      },
+      {
+        id: 2,
+        src: "https://images.unsplash.com/photo-1627556704302-624286467c65?w=1200&q=80&fit=crop",
+        alt: "Graduate smiling outdoors",
+        caption: "Pure joy, no filter needed",
+      },
+      {
+        id: 3,
+        src: "https://images.unsplash.com/photo-1580582932707-520aed937b7b?w=1200&q=80&fit=crop",
+        alt: "Graduation ceremony moment",
+        caption: "A moment worth framing",
+      },
+      {
+        id: 4,
+        src: "https://images.unsplash.com/photo-1541339907198-e08756dedf3f?w=1200&q=80&fit=crop",
+        alt: "Graduation portrait outdoors",
+        caption: "Soft light on a big day",
+      },
+      {
+        id: 5,
+        src: "https://images.unsplash.com/photo-1612872087720-bb876e2e67d1?w=1200&q=80&fit=crop",
+        alt: "Graduate holding diploma",
+        caption: "Years of effort, one perfect frame",
+      },
+    ],
+  },
+];
+
 export type GalleryItem = {
   id: number;
   title: string;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,16 @@
+export type ProjectImage = {
+  id: number;
+  src: string;
+  alt: string;
+  caption?: string;
+};
+
+export type Project = {
+  id: string;
+  title: string;
+  description: string;
+  location: string;
+  category: string;
+  coverImage: string;
+  images: ProjectImage[];
+};


### PR DESCRIPTION
## Summary
Refactors the flat gallery into a full project showcase. Visitors can browse named photography projects (Pattaya Beach, Kalaw Pre-Wedding, Ko Zin Graduation), each with a cover card, then dive into a masonry image grid and open any photo in a polished full-screen lightbox with animations, keyboard/swipe navigation, and dot indicators.

## Closes
- Closes #6 — Project Gallery: Data + Browsing Pages
- Closes #7 — Full-Screen Lightbox Viewer with Animations

## File Changes
- `src/types/project.ts` — `Project` and `ProjectImage` types
- `src/lib/portfolio-data.ts` — 3 dummy projects with 5 Unsplash images each
- `src/components/project-gallery.tsx` — Responsive project card grid with hover animations
- `src/components/project-detail-client.tsx` — Masonry image grid with hover overlay + caption reveal
- `src/components/lightbox.tsx` — Full-screen viewer: fade/scale animation, slide transitions, keyboard/swipe, dot indicators
- `src/app/gallery/page.tsx` — Updated to use ProjectGallery
- `src/app/gallery/[projectId]/page.tsx` — New SSG project detail route
- `src/components/__tests__/project-gallery.test.tsx` — 6 tests
- `src/components/__tests__/lightbox.test.tsx` — 11 tests

## Notes
- All 30 tests passing
- Build clean, all 3 project routes statically generated
- Dummy data uses Unsplash URLs — swap with real images when ready