### PR TITLE
fix: restructure blog card layout to 25/75 horizontal split

### DIFF
--- a/src/components/BlogCard.tsx
+++ b/src/components/BlogCard.tsx
@@ -10,30 +10,35 @@ export default function BlogCard({ blog }: BlogCardProps) {
   return (
     <Link href={`/blog/${blog.id}`}>
       <article className="group cursor-pointer overflow-hidden rounded-lg shadow-md transition-shadow hover:shadow-lg">
-        <div className="relative h-48 w-full overflow-hidden bg-gray-200">
-          <Image
-            src={blog.thumbnail}
-            alt={blog.title}
-            fill
-            className="object-cover transition-transform group-hover:scale-105"
-          />
-        </div>
-        <div className="p-4">
-          <h3 className="mb-2 line-clamp-2 text-lg font-semibold text-gray-900 group-hover:text-blue-600">
-            {blog.title}
-          </h3>
-          <p className="mb-3 line-clamp-2 text-sm text-gray-600">
-            {blog.excerpt}
-          </p>
-          <div className="flex items-center justify-between text-xs text-gray-500">
-            <span>{blog.author}</span>
-            <time dateTime={blog.publishedAt}>
-              {new Date(blog.publishedAt).toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'short',
-                day: 'numeric',
-              })}
-            </time>
+        <div className="flex flex-col sm:flex-row">
+          {/* Thumbnail - 25% width on desktop, full width on mobile */}
+          <div className="relative h-48 w-full sm:h-auto sm:w-1/4 overflow-hidden bg-gray-200 flex-shrink-0">
+            <Image
+              src={blog.thumbnail}
+              alt={blog.title}
+              fill
+              className="object-cover transition-transform group-hover:scale-105"
+            />
+          </div>
+          
+          {/* Content - 75% width on desktop, full width on mobile */}
+          <div className="flex w-full flex-col justify-center p-4 sm:w-3/4">
+            <h3 className="mb-2 line-clamp-2 text-lg font-semibold text-gray-900 group-hover:text-blue-600">
+              {blog.title}
+            </h3>
+            <p className="mb-3 line-clamp-2 text-sm text-gray-600">
+              {blog.excerpt}
+            </p>
+            <div className="flex items-center justify-between text-xs text-gray-500">
+              <span>{blog.author}</span>
+              <time dateTime={blog.publishedAt}>
+                {new Date(blog.publishedAt).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </time>
+            </div>
           </div>
         </div>
       </article>


### PR DESCRIPTION
## Summary
Restructure blog card layout from vertical stacking to horizontal layout with image on left (25%) and content on right (75%). Responsive design maintains full-width stack on mobile.

## File Changes
- `src/components/BlogCard.tsx` — Changed from vertical (image on top, content below) to horizontal flexbox layout
  - Image: 25% width on desktop, full-width on mobile
  - Content: 75% width on desktop, full-width on mobile
  - Improved spacing and alignment

## Acceptance Criteria
- [x] Thumbnail image positioned left at ~25% width (desktop)
- [x] Blog content (title, excerpt, etc) positioned right at ~75% width (desktop)
- [x] Responsive on mobile (full-width stack)
- [x] Images scale properly without distortion
- [x] Hover effects preserved
- [x] All tests passing (39 tests passed)

## Notes
- Closes #16
- Better visual hierarchy and content discovery
- Maintains accessibility and semantic HTML